### PR TITLE
add: TelePay address

### DIFF
--- a/src/addrbook.json
+++ b/src/addrbook.json
@@ -30,6 +30,7 @@
 
 "EQCtiv7PrMJImWiF2L5oJCgPnzp-VML2CAt5cbn1VsKAxLiE": "CryptoBot",
 "EQDd3NPNrWCvTA1pOJ9WetUdDCY_pJaNZVq0JMaara-TIp90": "Wallet Bot",
+"EQA5Pxp_EC9pTlxrvO59D1iqBqodajojullgf07ENKa22oSN": "TelePay",
 "EQBfAN7LfaUYgXZNw5Wc7GBgkEX2yhuJ5ka95J1JJwXXf4a8": "OKX",
 "EQCzFTXpNNsFu8IgJnRnkDyBCL2ry8KgZYiDi3Jt31ie8EIQ": "FTX",
 "EQB5lISMH8vLxXpqWph7ZutCS4tU4QdZtrUUpmtgDCsO73JR": "EXMO",


### PR DESCRIPTION
Hi, [TelePay](https://telepay.cash) is a payments gateway based on TON, the first of its kind in the ecosystem. It's aimed for creating merchant accounts, getting API keys and automating TON payments for businesses and individuals. It has a Web dashboard, a Telegram integration and more coming up.

Please, add our app to the address book, this is important to our users to identify the address in the scan. Thank you.

Here's more info:
https://t.me/TelePayCash/18

![telepay-seo-cover](https://user-images.githubusercontent.com/18733370/162160560-432d3243-cd71-483e-9d50-3003ca6cbbcb.png)