### PR TITLE
Add Connecton VPN address

### DIFF
--- a/src/addrbook.json
+++ b/src/addrbook.json
@@ -131,6 +131,7 @@
 "EQDOPNz5UIm3XuXOmCSk_1BvQLdQkMS-lmN8K404sQlyJPrd": "@mobile",
 "EQDI_6jJaNNjbPIppoW9HNLe63YAndVGRufU_bEkPzujMOxs": "Ton.Place",
 "EQDntPGyh1m8HMZ6i8LSuVCh1hyTh7ENXbRMaUNk8h6bxySU": "TON Footsteps",
+"EQBj1R6ZmJETs5AlRD1Tz27iweJqLYhlWYX_xV2YiSbil2HS": "Connecton VPN",
 
 "Ef83SoX0iL2bkzkK6Z9Q8kuOYVtrzh2my3pTiJTBfBV78Ton": { "isScam": true },
 "EQCMmytWnOEHdAEzPel9DBEn9jB7B6lq9jfsaF_Qa8FjNGmB": { "isScam": true },


### PR DESCRIPTION
Connecton VPN is an important project in the TON blockchain, which has just donated 10k TON to believers.ton.

It's the first VPN to ever accept TON as means of payment. Listed in TonKeeper and partner of @wallet as well.

More details:
https://connecton.surf